### PR TITLE
fix: stale-container sweep aborted the deploy when nothing was stale

### DIFF
--- a/scripts/deploy-vps.sh
+++ b/scripts/deploy-vps.sh
@@ -161,14 +161,17 @@ docker compose pull
 # still returned HTTP 200.
 echo "Clearing any stale renamed containers..."
 for svc in fusionauth-app fusionauth-db; do
-  # matches the <shorthash>_<name> form only, never the live container
-  docker ps -a --format '{{.Names}}' \
-    | grep -E "^[0-9a-f]{12}_${svc}$" \
-    | while read -r stale; do
-        echo "  removing stale container: ${stale}"
-        docker rm -f "${stale}" >/dev/null 2>&1 || true
-      done
+  # matches the <shorthash>_<name> form only, never the live container.
+  # `|| true` is required: grep exits 1 when nothing matches, and under
+  # `set -e` that aborts the deploy — which is the normal, healthy case.
+  stale_list=$(docker ps -a --format '{{.Names}}' \
+    | grep -E "^[0-9a-f]{12}_${svc}$" || true)
+  for stale in ${stale_list}; do
+    echo "  removing stale container: ${stale}"
+    docker rm -f "${stale}" >/dev/null 2>&1 || true
+  done
 done
+echo "  stale container sweep complete"
 
 # NOT zero-downtime: --force-recreate stops and replaces the container. The
 # gap is short but real, so the health check below is what makes the deploy


### PR DESCRIPTION
The sweep added in the previous PR piped `docker ps` into `grep`. **grep exits 1 when it matches nothing**, and `deploy-vps.sh` runs under `set -euo pipefail` — so the *healthy* case aborted the deploy:

```
Clearing any stale renamed containers...
##[error]Process completed with exit code 1
```

Captures the match list with `|| true` and iterates it, so a no-match is treated as the normal condition it is.

**Worth noting the previous PR still did its job.** The deploy failed *before* touching any container, so FusionAuth stayed up and served genuine `{"status":"Ok"}` throughout — where the same class of failure took auth offline earlier today. Failing safe is the point.

Verified under `set -euo pipefail` that a no-match no longer terminates.