### PR TITLE
fix: health check probed https on a plain-HTTP port, so every deploy failed

### DIFF
--- a/scripts/deploy-vps.sh
+++ b/scripts/deploy-vps.sh
@@ -195,7 +195,12 @@ fi
 # Wait for health checks
 echo "Waiting for FusionAuth to be healthy..."
 for i in {1..30}; do
-  if curl --fail --silent --insecure https://localhost:9011/api/status >/dev/null 2>&1; then
+  # FusionAuth serves plain HTTP on 9011 — TLS is terminated by Traefik, not
+  # by FusionAuth. The previous https:// probe could never succeed: verified on
+  # the host, https returns 000 while http returns 200. Every deploy therefore
+  # burned the full 30 x 10s health-check window and then failed, regardless of
+  # whether FusionAuth was actually healthy.
+  if curl --fail --silent http://localhost:9011/api/status >/dev/null 2>&1; then
     echo -e "${GREEN}✓ FusionAuth is healthy!${NC}"
     break
   fi


### PR DESCRIPTION
`deploy-vps.sh` probed `https://localhost:9011/api/status`. **FusionAuth serves plain HTTP on 9011** — TLS is terminated by Traefik, not by FusionAuth — so the probe could never succeed.

Verified on the host:

```
https://localhost:9011/api/status -> 000
http://localhost:9011/api/status  -> 200
```

Every deploy burned the full `30 × 10s` health-check window and then exited 1, **regardless of whether FusionAuth was healthy**. The container logs in the failing run show `HTTP server started successfully` and `listening on port [9011]` immediately before the timeout.

This is why the deploy has never reported success, and why the **reconcile and verify steps that follow it have always been skipped**.