### PR TITLE
fix: remove destructive compose-down fallback from deploy

### DIFF
--- a/scripts/deploy-vps.sh
+++ b/scripts/deploy-vps.sh
@@ -178,9 +178,22 @@ echo "  stale container sweep complete"
 # trustworthy, not the flag.
 echo "Deploying FusionAuth..."
 if ! docker compose up -d --force-recreate --remove-orphans; then
-  echo "compose up failed — retrying once after clearing conflicts"
-  docker compose down --remove-orphans || true
-  docker compose up -d --remove-orphans
+  # Deliberately NO `docker compose down` fallback here. It was tried on
+  # 2026-07-27 and made things worse: to resolve an app-container name
+  # conflict it tore down fusionauth-db and the network as well, turning a
+  # recoverable app problem into a full stack outage.
+  #
+  # Fail loudly with the state needed to fix it by hand instead. The
+  # containers carry `restart: unless-stopped`, so the previous instance
+  # generally recovers on its own — a clean failure is safer than an
+  # automated teardown of the database.
+  echo "ERROR: compose up failed. Current state:"
+  docker compose ps || true
+  docker ps -a --filter name=fusionauth --format '  {{.Names}}\t{{.Status}}' || true
+  echo
+  echo "If a name conflict is reported above, remove the orphaned container:"
+  echo "  docker rm -f <container-id>   # then re-run the deploy"
+  exit 1
 fi
 
 # A failed recreate can leave the service stopped. Fail loudly rather than


### PR DESCRIPTION
The fallback I added earlier ran `docker compose down --remove-orphans` when `up --force-recreate` failed. On 2026-07-27 that **turned a recoverable app-container name conflict into a full stack teardown** — it stopped and removed `fusionauth-db` and the network in order to fix a problem with `fusionauth-app`.

Escalating from *"one container won't recreate"* to *"destroy the database container"* is the wrong trade in every case. That was my error.

Now it fails loudly and prints what's needed to resolve by hand — `compose ps`, the container list, and the exact `docker rm -f` remedy. The containers carry `restart: unless-stopped`, so the previous instance generally recovers on its own, which a teardown would prevent.

**Deploy failures so far have all been safe** — FusionAuth stayed up and served genuine `{"status":"Ok"}` through every one. Preserving that property matters more than making the script self-heal.